### PR TITLE
Sprint 0 plumbing: readmes, contracts lint, and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,19 @@ jobs:
       - run: spectral --version
       - run: spectral lint "libs/contracts/*.yaml" -f stylish -D --fail-severity=error
 
-  build_and_push:
+  unit_tests:
     needs: contracts_lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pytest
+      - run: pytest -q
+
+  build_and_push:
+    needs: unit_tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/libs/contracts/.spectral.yaml
+++ b/libs/contracts/.spectral.yaml
@@ -1,0 +1,7 @@
+extends: ["spectral:oas"]   # built-in OpenAPI rules
+formats: ["oas3", "oas3_1"] # lint OAS 3.0 and 3.1
+rules:
+  oas3-schema: error
+  info-contact: warn
+  license-url: warn
+  operation-operationId-unique: warn

--- a/services/analytics/README.md
+++ b/services/analytics/README.md
@@ -1,0 +1,2 @@
+# Analytics Service
+

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -1,0 +1,2 @@
+# Auth Service
+

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -1,0 +1,2 @@
+# Chat Service
+

--- a/services/content/README.md
+++ b/services/content/README.md
@@ -1,0 +1,2 @@
+# Content Service
+

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -1,0 +1,2 @@
+# Notifications Service
+

--- a/services/profile/README.md
+++ b/services/profile/README.md
@@ -1,0 +1,2 @@
+# Profile Service
+

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- add minimal README files for service directories
- add Spectral configuration for contract workspace
- run placeholder unit tests in CI before building images

## Testing
- `python -m pytest`
- `spectral lint "libs/contracts/*.yaml" -f stylish -D --fail-severity=error`


------
https://chatgpt.com/codex/tasks/task_e_689b3feb3a9083308fbd9fc7253587ee