### PR TITLE
G0.3 ci: reference Spectral ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm i -g @stoplight/spectral-cli
       - run: spectral --version
-      - run: spectral lint "libs/contracts/*.yaml" -f stylish -D --fail-severity=error
+      - run: spectral lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -f stylish -D --fail-severity=error
 
   unit_tests:
     needs: contracts_lint


### PR DESCRIPTION
## Summary
- ensure CI uses contracts' Spectral ruleset so linter can run

## Testing
- `spectral lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -f stylish -D --fail-severity=error`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b434145dc83309707043035218eb7