### PR TITLE
P1: bootstrap namespaces and gateway jwt auth

### DIFF
--- a/deploy/helm/analytics/templates/ingress.yaml
+++ b/deploy/helm/analytics/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/api-gateway/templates/configmap.yaml
+++ b/deploy/helm/api-gateway/templates/configmap.yaml
@@ -29,8 +29,36 @@ data:
                                 prefix_rewrite: "/"
 {{- end }}
                     http_filters:
+                      - name: envoy.filters.http.jwt_authn
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                          providers:
+                            default:
+                              issuer: "{{ .Values.jwtAuthn.issuer }}"
+                              remote_jwks:
+                                http_uri:
+                                  uri: "{{ .Values.jwtAuthn.jwksUri }}"
+                                  cluster: jwks_cluster
+                                  timeout: 5s
+                              forward_payload_header: "x-jwt-payload"
+                          rules:
+                            - match: { prefix: "/" }
+                              requires: { provider_name: "default" }
                       - name: envoy.filters.http.router
       clusters:
+        - name: jwks_cluster
+          type: STRICT_DNS
+          connect_timeout: 2s
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: jwks_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: "{{ .Values.jwtAuthn.jwksHost }}"
+                          port_value: {{ .Values.jwtAuthn.jwksPort }}
 {{- range $name, $cfg := .Values.routes }}
         - name: "{{ $name }}_cluster"
           type: STRICT_DNS

--- a/deploy/helm/api-gateway/templates/ingress.yaml
+++ b/deploy/helm/api-gateway/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: api-gateway
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/api-gateway/values.dev.yaml
+++ b/deploy/helm/api-gateway/values.dev.yaml
@@ -1,2 +1,8 @@
 ingress:
   host: "api.45.146.164.70.nip.io"
+
+jwtAuthn:
+  issuer: "https://auth.dev.example.com/"
+  jwksUri: "https://auth.dev.example.com/.well-known/jwks.json"
+  jwksHost: "auth.dev.example.com"
+  jwksPort: 443

--- a/deploy/helm/api-gateway/values.yaml
+++ b/deploy/helm/api-gateway/values.yaml
@@ -13,6 +13,12 @@ service:
   type: ClusterIP
   port: 8080
 
+jwtAuthn:
+  issuer: ""
+  jwksUri: ""
+  jwksHost: ""
+  jwksPort: 443
+
 routes:
   auth:           { serviceName: auth,           servicePort: 8000 }
   profile:        { serviceName: profile,        servicePort: 8000 }

--- a/deploy/helm/auth/templates/ingress.yaml
+++ b/deploy/helm/auth/templates/ingress.yaml
@@ -4,7 +4,13 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    nginx.ingress.kubernetes.io/limit-rps: "5"
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/chat/templates/ingress.yaml
+++ b/deploy/helm/chat/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/content/templates/ingress.yaml
+++ b/deploy/helm/content/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/notifications/templates/ingress.yaml
+++ b/deploy/helm/notifications/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/helm/profile/templates/ingress.yaml
+++ b/deploy/helm/profile/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "svc.fullname" . }}
   annotations:
-{{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:

--- a/deploy/k8s/namespaces.yaml
+++ b/deploy/k8s/namespaces.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod


### PR DESCRIPTION
## Summary
- add k8s namespaces for dev/staging/prod
- wire websocket headers into ingress templates
- configure Envoy JWT authn and JWKS cluster
- rate limit auth ingress

## Testing
- `pytest`
- `npx --yes @stoplight/spectral-cli lint libs/contracts/*.yaml` *(fails: No ruleset has been found)*

------
https://chatgpt.com/codex/tasks/task_e_689b47931abc8330ba8860a7d2b72d67