### PR TITLE
A3.1 feat: expand auth contract

### DIFF
--- a/libs/contracts/.spectral.yaml
+++ b/libs/contracts/.spectral.yaml
@@ -5,3 +5,11 @@ rules:
   info-contact: warn
   license-url: warn
   operation-operationId-unique: warn
+  error-response-structure:
+    description: 4xx/5xx responses must reference the Error schema
+    given: "$..responses[?(@property && @property.match(/^(4|5)\\d{2}$/))]"
+    then:
+      field: content.application/json.schema.$ref
+      function: pattern
+      functionOptions:
+        match: '#/components/schemas/Error$'

--- a/libs/contracts/auth.yaml
+++ b/libs/contracts/auth.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Auth API
-  version: 0.1.0
+  version: 0.2.0
 paths:
   /healthz:
     get:
@@ -18,14 +18,11 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                phone: { type: string }
-              required: [phone]
+              $ref: '#/components/schemas/PhoneSendCodeRequest'
       responses:
         '200': { description: Code sent }
-        '400': { description: Bad request }
-        '429': { description: Too many requests }
+        '400': { $ref: '#/components/responses/Error400' }
+        '429': { $ref: '#/components/responses/Error429' }
 
   /api/auth/phone/verify:
     post:
@@ -35,14 +32,327 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                phone: { type: string }
-                code: { type: string }
-                email: { type: string }
-                password: { type: string }
-              required: [phone, code]
+              $ref: '#/components/schemas/PhoneVerifyRequest'
       responses:
-        '200': { description: OK }
-        '401': { description: Unauthorized }
-        '423': { description: Locked }
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenPair'
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '423': { $ref: '#/components/responses/Error423' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/email/register:
+    post:
+      summary: Register with email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailRegisterRequest'
+      responses:
+        '200': { description: Verification sent }
+        '400': { $ref: '#/components/responses/Error400' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/email/verify:
+    post:
+      summary: Verify email token and issue tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailVerifyRequest'
+      responses:
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenPair'
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/login:
+    post:
+      summary: Login with email and password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailLoginRequest'
+      responses:
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenPair'
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '423': { $ref: '#/components/responses/Error423' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/password/reset/request:
+    post:
+      summary: Request password reset email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetRequest'
+      responses:
+        '200': { description: Reset email sent }
+        '400': { $ref: '#/components/responses/Error400' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/password/reset/confirm:
+    post:
+      summary: Confirm password reset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetConfirmRequest'
+      responses:
+        '200': { description: Password updated }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/refresh:
+    post:
+      summary: Refresh access token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenPair'
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/logout:
+    post:
+      summary: Logout and invalidate refresh token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogoutRequest'
+      responses:
+        '204': { description: Logged out }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+
+  /api/auth/email/update/request:
+    post:
+      summary: Request email update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailUpdateRequest'
+      responses:
+        '200': { description: Verification sent }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/email/update/confirm:
+    post:
+      summary: Confirm email update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailUpdateConfirmRequest'
+      responses:
+        '200': { description: Email updated }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/phone/update/send-code:
+    post:
+      summary: Send code for phone update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneSendCodeRequest'
+      responses:
+        '200': { description: Code sent }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+  /api/auth/phone/update/verify:
+    post:
+      summary: Verify phone update code
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneUpdateVerifyRequest'
+      responses:
+        '200': { description: Phone updated }
+        '400': { $ref: '#/components/responses/Error400' }
+        '401': { $ref: '#/components/responses/Error401' }
+        '423': { $ref: '#/components/responses/Error423' }
+        '429': { $ref: '#/components/responses/Error429' }
+
+components:
+  schemas:
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+    TokenPair:
+      type: object
+      required: [access_token, refresh_token]
+      properties:
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+    EmailRegisterRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+    EmailVerifyRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+    EmailLoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+        remember_me:
+          type: boolean
+          default: false
+    PasswordResetRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+    PasswordResetConfirmRequest:
+      type: object
+      required: [token, new_password]
+      properties:
+        token:
+          type: string
+        new_password:
+          type: string
+    RefreshRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
+    LogoutRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
+    EmailUpdateRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+    EmailUpdateConfirmRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+    PhoneSendCodeRequest:
+      type: object
+      required: [phone]
+      properties:
+        phone:
+          type: string
+    PhoneVerifyRequest:
+      type: object
+      required: [phone, code]
+      properties:
+        phone:
+          type: string
+        code:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+    PhoneUpdateVerifyRequest:
+      type: object
+      required: [phone, code]
+      properties:
+        phone:
+          type: string
+        code:
+          type: string
+  responses:
+    Error400:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Error401:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Error423:
+      description: Locked
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Error429:
+      description: Too many requests
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'


### PR DESCRIPTION
## Summary
- expand Auth API contract with email registration, login, password reset, refresh, logout, and update flows
- define reusable error schema and enforce via Spectral rule

## Testing
- `npx @stoplight/spectral-cli lint -r libs/contracts/.spectral.yaml libs/contracts/*.yaml -D`
- `ruff check .`
- `black --check .` *(fails: would reformat 6 files)*
- `pytest -q`
- `gofmt -l .`
- `golangci-lint run`
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `eslint .` *(fails: missing config)*
- `npm test -s`
- `docker build -f services/auth/Dockerfile services/auth` *(fails: docker not installed)*
- `helm template deploy/helm/auth | kubeval --ignore-missing-schemas` *(fails: helm, kubeval not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c9ddfdadc83308bf19a41690ae4d5