### PR TITLE
A3.2 feat: add auth models and migrations

### DIFF
--- a/services/auth/app/db/migrations/alembic.ini
+++ b/services/auth/app/db/migrations/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = services/auth/app/db/migrations
+sqlalchemy.url = sqlite:///./auth.db

--- a/services/auth/app/db/migrations/env.py
+++ b/services/auth/app/db/migrations/env.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[5]))
+from logging.config import fileConfig
+import os
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from services.auth.app.db import models  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    try:
+        fileConfig(config.config_file_name)
+    except KeyError:
+        pass
+
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option(
+        "sqlalchemy.url", os.getenv("DATABASE_URL", "sqlite:///./auth.db")
+    )
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/auth/app/db/migrations/versions/0001_initial.py
+++ b/services/auth/app/db/migrations/versions/0001_initial.py
@@ -1,0 +1,102 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("login_type", sa.String(length=10), nullable=False),
+        sa.Column("phone", sa.String(length=15), unique=True),
+        sa.Column("email", sa.String(length=255), unique=True),
+        sa.Column("password_hash", sa.String(length=255)),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("blocked_until", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "email_verifications",
+        sa.Column("token", sa.String(length=64), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(length=36),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_email_verifications_token", "email_verifications", ["token"], unique=True
+    )
+
+    op.create_table(
+        "password_resets",
+        sa.Column("token", sa.String(length=64), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(length=36),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_password_resets_token", "password_resets", ["token"], unique=True
+    )
+
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("token", sa.String(length=64), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(length=36),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("family", sa.String(length=36), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_refresh_tokens_user_id_family", "refresh_tokens", ["user_id", "family"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_user_id_family", table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")
+    op.drop_index("ix_password_resets_token", table_name="password_resets")
+    op.drop_table("password_resets")
+    op.drop_index("ix_email_verifications_token", table_name="email_verifications")
+    op.drop_table("email_verifications")
+    op.drop_table("users")

--- a/services/auth/app/db/models.py
+++ b/services/auth/app/db/models.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    login_type = Column(String(10), nullable=False)
+    phone = Column(String(15), unique=True)
+    email = Column(String(255), unique=True)
+    password_hash = Column(String(255))
+    is_active = Column(Boolean, nullable=False, default=False)
+    blocked_until = Column(DateTime(timezone=True))
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class EmailVerification(Base):
+    __tablename__ = "email_verifications"
+
+    token = Column(String(64), primary_key=True)
+    user_id = Column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class PasswordReset(Base):
+    __tablename__ = "password_resets"
+
+    token = Column(String(64), primary_key=True)
+    user_id = Column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    token = Column(String(64), primary_key=True)
+    user_id = Column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    family = Column(String(36), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+    __table_args__ = (Index("ix_refresh_tokens_user_id_family", "user_id", "family"),)

--- a/services/auth/app/schemas.py
+++ b/services/auth/app/schemas.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserRead(BaseModel):
+    id: UUID
+    email: EmailStr
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class EmailVerificationRead(BaseModel):
+    token: str
+    user_id: UUID
+    expires_at: datetime
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class PasswordResetRead(BaseModel):
+    token: str
+    user_id: UUID
+    expires_at: datetime
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class RefreshTokenRead(BaseModel):
+    token: str
+    user_id: UUID
+    family: UUID
+    expires_at: datetime
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/services/auth/tests/test_models.py
+++ b/services/auth/tests/test_models.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command, config
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from services.auth.app.db import models
+
+
+@pytest.fixture(scope="module")
+def engine():
+    cfg = config.Config("services/auth/app/db/migrations/alembic.ini")
+    cfg.set_main_option("script_location", "services/auth/app/db/migrations")
+    db_path = "sqlite:///./test_auth.db"
+    cfg.set_main_option("sqlalchemy.url", db_path)
+    command.upgrade(cfg, "head")
+    eng = create_engine(db_path)
+    yield eng
+    eng.dispose()
+    if os.path.exists("test_auth.db"):
+        os.remove("test_auth.db")
+
+
+@pytest.fixture()
+def db(engine):
+    with Session(engine) as session:
+        yield session
+
+
+def test_unique_user_email(db):
+    user1 = models.User(
+        id=str(uuid.uuid4()),
+        login_type="email",
+        email="a@example.com",
+        password_hash="x",
+    )
+    db.add(user1)
+    db.commit()
+    user2 = models.User(
+        id=str(uuid.uuid4()),
+        login_type="email",
+        email="a@example.com",
+        password_hash="y",
+    )
+    db.add(user2)
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_unique_tokens(db):
+    user = models.User(
+        id=str(uuid.uuid4()),
+        login_type="email",
+        email="b@example.com",
+        password_hash="x",
+    )
+    db.add(user)
+    db.commit()
+
+    ev1 = models.EmailVerification(
+        token="tok", user_id=user.id, expires_at=datetime.utcnow() + timedelta(hours=1)
+    )
+    db.add(ev1)
+    db.commit()
+    db.expunge(ev1)
+    ev2 = models.EmailVerification(
+        token="tok", user_id=user.id, expires_at=datetime.utcnow() + timedelta(hours=1)
+    )
+    db.add(ev2)
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+    pr1 = models.PasswordReset(
+        token="rtok", user_id=user.id, expires_at=datetime.utcnow() + timedelta(hours=1)
+    )
+    db.add(pr1)
+    db.commit()
+    db.expunge(pr1)
+    pr2 = models.PasswordReset(
+        token="rtok", user_id=user.id, expires_at=datetime.utcnow() + timedelta(hours=1)
+    )
+    db.add(pr2)
+
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+
+def test_refresh_token_index(engine):
+    inspector = inspect(engine)
+    indexes = inspector.get_indexes("refresh_tokens")
+    assert any(idx["name"] == "ix_refresh_tokens_user_id_family" for idx in indexes)


### PR DESCRIPTION
## Summary
- define SQLAlchemy models and Pydantic schemas for auth tables
- add initial Alembic migration for users, email_verifications, password_resets, and refresh_tokens
- cover model constraints and indexes with pytest

## Testing
- `npx -y @stoplight/spectral-cli lint libs/contracts/*.yaml -D --ruleset libs/contracts/.spectral.yaml`
- `ruff check services/auth/app/db/models.py services/auth/app/schemas.py services/auth/app/db/migrations/env.py services/auth/app/db/migrations/versions/0001_initial.py services/auth/tests/test_models.py`
- `black --check services/auth/app/db/models.py services/auth/app/schemas.py services/auth/app/db/migrations/env.py services/auth/app/db/migrations/versions/0001_initial.py services/auth/tests/test_models.py`
- `pytest -q`
- `gofmt -l .` *(no files)*
- `golangci-lint run` *(no module)*
- `go test ./...` *(no module)*
- `eslint .` *(missing config)*
- `npm test -s`
- `docker build -f services/auth/Dockerfile services/auth` *(docker not installed)*
- `helm template deploy/helm/auth | kubeval --ignore-missing-schemas` *(helm and kubeval not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ca364e36883308fa6a53b530d0411