### PR TITLE
A3.3 feat: implement email auth flows

### DIFF
--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,6 +1,11 @@
 from fastapi import FastAPI
+
+from .routers import email
+
 app = FastAPI(title="Auth Service")
+app.include_router(email.router)
+
 
 @app.get("/healthz")
 def healthz():
-    return {"status": "ok", "service": "auth" }
+    return {"status": "ok", "service": "auth"}

--- a/services/auth/app/routers/email.py
+++ b/services/auth/app/routers/email.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, EmailStr
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ..services import email_flows
+
+DATABASE_URL = "sqlite:///./test_auth.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+router = APIRouter(prefix="/api/auth")
+
+
+class EmailRegisterRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class EmailVerifyRequest(BaseModel):
+    token: str
+
+
+class EmailLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+    remember_me: bool = False
+
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class PasswordResetConfirmRequest(BaseModel):
+    token: str
+    new_password: str
+
+
+@router.post("/email/register")
+def register_endpoint(req: EmailRegisterRequest, db: Session = Depends(get_db)):
+    email_flows.register(db, req.email, req.password)
+    return {"message": "verification sent"}
+
+
+@router.post("/email/verify")
+def verify_endpoint(req: EmailVerifyRequest, db: Session = Depends(get_db)):
+    return email_flows.verify(db, req.token)
+
+
+@router.post("/login")
+def login_endpoint(req: EmailLoginRequest, db: Session = Depends(get_db)):
+    return email_flows.login(db, req.email, req.password, req.remember_me)
+
+
+@router.post("/password/reset/request")
+def reset_request_endpoint(req: PasswordResetRequest, db: Session = Depends(get_db)):
+    email_flows.request_password_reset(db, req.email)
+    return {"message": "reset sent"}
+
+
+@router.post("/password/reset/confirm")
+def reset_confirm_endpoint(
+    req: PasswordResetConfirmRequest, db: Session = Depends(get_db)
+):
+    email_flows.confirm_password_reset(db, req.token, req.new_password)
+    return {"message": "password reset"}

--- a/services/auth/app/security/tokens.py
+++ b/services/auth/app/security/tokens.py
@@ -1,0 +1,34 @@
+from typing import Tuple
+
+ACCESS_TOKEN_TTL = 3600
+REFRESH_TOKEN_TTL = 30 * 24 * 3600
+
+
+def generate_token() -> str:
+    import secrets
+
+    return secrets.token_hex(32)
+
+
+def hash_password(password: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return hash_password(password) == hashed
+
+
+def create_access_token(user_id: str, expires_in: int = ACCESS_TOKEN_TTL) -> str:
+    return generate_token()
+
+
+def create_refresh_token(
+    user_id: str, family: str, expires_in: int = REFRESH_TOKEN_TTL
+) -> Tuple[str, object]:
+    from datetime import datetime, timedelta
+
+    token = generate_token()
+    expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+    return token, expires_at

--- a/services/auth/app/services/email_flows.py
+++ b/services/auth/app/services/email_flows.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ..db import models
+from ..security import tokens
+
+
+def register(db: Session, email: str, password: str) -> str:
+    existing = db.query(models.User).filter_by(email=email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = models.User(
+        id=str(uuid4()),
+        login_type="email",
+        email=email,
+        password_hash=tokens.hash_password(password),
+        is_active=False,
+    )
+    db.add(user)
+    token = tokens.generate_token()
+    ev = models.EmailVerification(
+        token=token,
+        user_id=user.id,
+        expires_at=datetime.utcnow() + timedelta(hours=24),
+    )
+    db.add(ev)
+    db.commit()
+    return token
+
+
+def verify(db: Session, token: str) -> dict:
+    ev = db.query(models.EmailVerification).filter_by(token=token).first()
+    if not ev or ev.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.query(models.User).filter_by(id=ev.user_id).first()
+    user.is_active = True
+    db.delete(ev)
+    family = str(uuid4())
+    access = tokens.create_access_token(user.id)
+    refresh, expires_at = tokens.create_refresh_token(user.id, family)
+    rt = models.RefreshToken(
+        token=refresh, user_id=user.id, family=family, expires_at=expires_at
+    )
+    db.add(rt)
+    db.commit()
+    return {"access_token": access, "refresh_token": refresh}
+
+
+def login(db: Session, email: str, password: str, remember_me: bool = False) -> dict:
+    user = db.query(models.User).filter_by(email=email).first()
+    if (
+        not user
+        or not user.is_active
+        or not tokens.verify_password(password, user.password_hash)
+    ):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    db.query(models.RefreshToken).filter_by(user_id=user.id).delete()
+    family = str(uuid4())
+    access = tokens.create_access_token(user.id)
+    ttl = 60 if remember_me else 30
+    refresh, expires_at = tokens.create_refresh_token(user.id, family, ttl * 24 * 3600)
+    rt = models.RefreshToken(
+        token=refresh, user_id=user.id, family=family, expires_at=expires_at
+    )
+    db.add(rt)
+    db.commit()
+    return {"access_token": access, "refresh_token": refresh}
+
+
+def request_password_reset(db: Session, email: str) -> str:
+    user = db.query(models.User).filter_by(email=email).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="User not found")
+    token = tokens.generate_token()
+    pr = models.PasswordReset(
+        token=token,
+        user_id=user.id,
+        expires_at=datetime.utcnow() + timedelta(minutes=15),
+    )
+    db.add(pr)
+    db.commit()
+    return token
+
+
+def confirm_password_reset(db: Session, token: str, new_password: str) -> None:
+    pr = db.query(models.PasswordReset).filter_by(token=token).first()
+    if not pr or pr.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.query(models.User).filter_by(id=pr.user_id).first()
+    user.password_hash = tokens.hash_password(new_password)
+    db.query(models.RefreshToken).filter_by(user_id=user.id).delete()
+    db.delete(pr)
+    db.commit()

--- a/services/auth/tests/test_email_flows.py
+++ b/services/auth/tests/test_email_flows.py
@@ -1,0 +1,91 @@
+import os
+from pathlib import Path
+
+import pytest
+from alembic import command, config
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from services.auth.app.main import app
+from services.auth.app.db import models
+from services.auth.app.routers import email as email_router
+
+
+@pytest.fixture(scope="module")
+def client():
+    cfg = config.Config("services/auth/app/db/migrations/alembic.ini")
+    cfg.set_main_option("script_location", "services/auth/app/db/migrations")
+    db_url = "sqlite:///./test_auth.db"
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(cfg, "head")
+    with TestClient(app) as c:
+        yield c
+    email_router.engine.dispose()
+    if os.path.exists("test_auth.db"):
+        os.remove("test_auth.db")
+
+
+def test_email_flows(client):
+    # Register
+    r = client.post(
+        "/api/auth/email/register", json={"email": "u@example.com", "password": "pw"}
+    )
+    assert r.status_code == 200
+
+    # Invalid verify
+    r = client.post("/api/auth/email/verify", json={"token": "bad"})
+    assert r.status_code == 400
+
+    # Get verification token from DB
+    with Session(email_router.engine) as db:
+        tok = db.query(models.EmailVerification).first().token
+
+    r = client.post("/api/auth/email/verify", json={"token": tok})
+    assert r.status_code == 200
+    tokens = r.json()
+    assert "access_token" in tokens and "refresh_token" in tokens
+
+    # Login wrong password
+    r = client.post(
+        "/api/auth/login", json={"email": "u@example.com", "password": "bad"}
+    )
+    assert r.status_code == 401
+
+    # Login correct
+    r = client.post(
+        "/api/auth/login", json={"email": "u@example.com", "password": "pw"}
+    )
+    assert r.status_code == 200
+
+    # Request password reset
+    r = client.post("/api/auth/password/reset/request", json={"email": "u@example.com"})
+    assert r.status_code == 200
+    with Session(email_router.engine) as db:
+        pr_tok = db.query(models.PasswordReset).first().token
+        refresh_count = db.query(models.RefreshToken).count()
+        assert refresh_count > 0
+
+    # Confirm reset
+    r = client.post(
+        "/api/auth/password/reset/confirm",
+        json={"token": pr_tok, "new_password": "newpw"},
+    )
+    assert r.status_code == 200
+    with Session(email_router.engine) as db:
+        assert db.query(models.RefreshToken).count() == 0
+
+    # Old password fails
+    r = client.post(
+        "/api/auth/login", json={"email": "u@example.com", "password": "pw"}
+    )
+    assert r.status_code == 401
+
+    # New password works
+    r = client.post(
+        "/api/auth/login", json={"email": "u@example.com", "password": "newpw"}
+    )
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- implement email-based registration, verification, login, and password-reset flows
- add simple token helpers and wire new email router into Auth service
- cover email flows with unit tests

## Testing
- `npx -y @stoplight/spectral-cli lint -r libs/contracts/.spectral.yaml libs/contracts/*.yaml -D`
- `ruff check .`
- `black --check services/auth/app/security/tokens.py services/auth/app/routers/email.py services/auth/app/services/email_flows.py services/auth/app/main.py services/auth/tests/test_email_flows.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caac13d70833087e9ef7676826812