### PR TITLE
A3.4 feat: implement phone limits and refresh rotation

### DIFF
--- a/services/auth/app/security/rate_limit.py
+++ b/services/auth/app/security/rate_limit.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from fastapi import HTTPException
+
+
+class WindowRateLimiter:
+    """Simple in-memory sliding window rate limiter."""
+
+    def __init__(self, limit: int, window_seconds: int) -> None:
+        self.limit = limit
+        self.window = timedelta(seconds=window_seconds)
+        self._history: Dict[str, List[datetime]] = {}
+
+    def check(self, key: str) -> bool:
+        now = datetime.utcnow()
+        items = self._history.get(key, [])
+        items = [t for t in items if now - t < self.window]
+        if len(items) >= self.limit:
+            self._history[key] = items
+            return False
+        items.append(now)
+        self._history[key] = items
+        return True
+
+    def reset(self) -> None:
+        self._history.clear()
+
+
+phone_limiter = WindowRateLimiter(limit=1, window_seconds=30)
+ip_limiter = WindowRateLimiter(limit=5, window_seconds=3600)
+
+
+def check_limits(phone: str, ip: str) -> None:
+    """Raise HTTPException if phone or IP exceed limits."""
+    if not phone_limiter.check(phone):
+        raise HTTPException(status_code=429, detail="Too many requests for phone")
+    if not ip_limiter.check(ip):
+        raise HTTPException(status_code=429, detail="Too many requests for IP")
+
+
+def reset() -> None:
+    """Reset limiter state (used in tests)."""
+    phone_limiter.reset()
+    ip_limiter.reset()

--- a/services/auth/app/security/refresh_family.py
+++ b/services/auth/app/security/refresh_family.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Optional
+
+from . import tokens
+
+
+@dataclass
+class RefreshToken:
+    token: str
+    user_id: str
+    family: str
+    prev_id: Optional[str]
+    revoked_at: Optional[datetime]
+    expires_at: datetime
+
+
+_store: Dict[str, RefreshToken] = {}
+
+
+def issue_token(
+    user_id: str, family: str, prev_id: Optional[str] = None
+) -> RefreshToken:
+    token, expires_at = tokens.create_refresh_token(user_id, family)
+    rt = RefreshToken(
+        token=token,
+        user_id=user_id,
+        family=family,
+        prev_id=prev_id,
+        revoked_at=None,
+        expires_at=expires_at,
+    )
+    _store[token] = rt
+    return rt
+
+
+def rotate(token: str) -> RefreshToken:
+    rt = _store.get(token)
+    if not rt or rt.revoked_at:
+        raise ValueError("invalid token")
+    rt.revoked_at = datetime.utcnow()
+    return issue_token(rt.user_id, rt.family, prev_id=token)
+
+
+def revoke_family(family: str) -> None:
+    now = datetime.utcnow()
+    for rt in _store.values():
+        if rt.family == family:
+            rt.revoked_at = now
+
+
+def reset() -> None:
+    _store.clear()

--- a/services/auth/app/services/phone_flows.py
+++ b/services/auth/app/services/phone_flows.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+from fastapi import HTTPException
+
+from ..security import rate_limit
+
+
+@dataclass
+class PhoneCode:
+    code: str
+    sent_at: datetime
+    attempts: int = 0
+    locked_until: Optional[datetime] = None
+
+
+_codes: Dict[str, PhoneCode] = {}
+
+
+def _generate_code() -> str:
+    import random
+
+    return f"{random.randint(0,999999):06d}"
+
+
+def send_code(phone: str, ip: str) -> str:
+    rate_limit.check_limits(phone, ip)
+    code = _generate_code()
+    _codes[phone] = PhoneCode(code=code, sent_at=datetime.utcnow())
+    return code
+
+
+def verify_code(phone: str, code: str) -> None:
+    entry = _codes.get(phone)
+    if not entry:
+        raise HTTPException(status_code=400, detail="code not requested")
+    now = datetime.utcnow()
+    if entry.locked_until and now < entry.locked_until:
+        raise HTTPException(status_code=423, detail="phone locked")
+    if code != entry.code:
+        entry.attempts += 1
+        if entry.attempts >= 5:
+            entry.locked_until = now + timedelta(hours=1)
+            raise HTTPException(status_code=423, detail="phone locked")
+        raise HTTPException(status_code=400, detail="invalid code")
+    del _codes[phone]
+
+
+def reset() -> None:
+    _codes.clear()
+    rate_limit.reset()

--- a/services/auth/tests/test_limits_rotation.py
+++ b/services/auth/tests/test_limits_rotation.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+import pytest
+from fastapi import HTTPException
+
+from services.auth.app.services import phone_flows
+from services.auth.app.security import refresh_family
+
+
+def setup_function(function):
+    phone_flows.reset()
+    refresh_family.reset()
+
+
+def test_rate_limit_and_lockout():
+    phone_flows.send_code("+79990000000", "1.1.1.1")
+    with pytest.raises(HTTPException) as exc:
+        phone_flows.send_code("+79990000000", "1.1.1.1")
+    assert exc.value.status_code == 429
+
+    for i in range(5):
+        phone_flows.send_code(f"+7999000001{i}", "2.2.2.2")
+    with pytest.raises(HTTPException) as exc:
+        phone_flows.send_code("+79990000016", "2.2.2.2")
+    assert exc.value.status_code == 429
+
+    code = phone_flows.send_code("+79990000017", "3.3.3.3")
+    for _ in range(4):
+        with pytest.raises(HTTPException) as exc:
+            phone_flows.verify_code("+79990000017", "000000")
+        assert exc.value.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        phone_flows.verify_code("+79990000017", "000000")
+    assert exc.value.status_code == 423
+    with pytest.raises(HTTPException) as exc:
+        phone_flows.verify_code("+79990000017", code)
+    assert exc.value.status_code == 423
+
+
+def test_refresh_rotation_and_revoke():
+    rt1 = refresh_family.issue_token("u1", "fam1")
+    rt2 = refresh_family.rotate(rt1.token)
+    assert rt2.prev_id == rt1.token
+    assert refresh_family._store[rt1.token].revoked_at is not None
+
+    rt3 = refresh_family.rotate(rt2.token)
+    refresh_family.revoke_family(rt3.family)
+    assert refresh_family._store[rt2.token].revoked_at is not None
+    assert refresh_family._store[rt3.token].revoked_at is not None


### PR DESCRIPTION
## Summary
- add in-memory rate limiter for phone/IP throttling
- manage refresh token families with rotation and revocation
- implement phone OTP lockouts and tests for limits and token rotation

## Testing
- `npx --yes @stoplight/spectral-cli lint libs/contracts/*.yaml -r libs/contracts/.spectral.yaml -D`
- `ruff check .`
- `black --check services/auth`
- `pytest services/auth/tests/test_limits_rotation.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb0266328833087c599844b742503