### PR TITLE
A3.5 feat: add probes and metrics to auth

### DIFF
--- a/deploy/helm/auth/templates/deployment.yaml
+++ b/deploy/helm/auth/templates/deployment.yaml
@@ -15,18 +15,48 @@ spec:
       imagePullSecrets:
 {{- toYaml . | nindent 12 }}
       {{- end }}
-      containers:
-        - name: {{ include "svc.fullname" . }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-          env:
-{{- toYaml .Values.env | nindent 16 }}
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+        containers:
+          - name: {{ include "svc.fullname" . }}
+            image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            ports:
+              - name: http
+                containerPort: {{ .Values.service.port }}
+            env:
+{{- toYaml .Values.env | nindent 12 }}
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: http
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: http
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            resources:
+{{- toYaml .Values.resources | nindent 12 }}
+
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "svc.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "svc.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/auth/values.dev.yaml
+++ b/deploy/helm/auth/values.dev.yaml
@@ -9,3 +9,17 @@ imagePullSecrets:
 
 ingress:
   enabled: false  # exposed only via api-gateway
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70

--- a/deploy/helm/auth/values.yaml
+++ b/deploy/helm/auth/values.yaml
@@ -10,7 +10,19 @@ imagePullSecrets: []  # e.g. [{ name: ghcr }]
 service:
   port: 8000
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
 
 env: []  # e.g. [{ name: SOME_VAR, value: "value" }]
 

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,11 +1,18 @@
 from fastapi import FastAPI
 
+from .metrics import setup_metrics
 from .routers import email
 
 app = FastAPI(title="Auth Service")
 app.include_router(email.router)
+setup_metrics(app)
 
 
 @app.get("/healthz")
 def healthz():
+    return {"status": "ok", "service": "auth"}
+
+
+@app.get("/readyz")
+def readyz():
     return {"status": "ok", "service": "auth"}

--- a/services/auth/app/metrics.py
+++ b/services/auth/app/metrics.py
@@ -1,0 +1,39 @@
+import time
+from fastapi import APIRouter, Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Prometheus metrics
+REQUEST_COUNT = Counter(
+    "auth_requests_total", "Total HTTP requests", ["method", "path", "status_code"]
+)
+REQUEST_LATENCY = Histogram(
+    "auth_request_duration_seconds", "Request duration in seconds", ["path"]
+)
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware to record request metrics."""
+
+    async def dispatch(self, request: Request, call_next):
+        start = time.time()
+        response = await call_next(request)
+        REQUEST_COUNT.labels(
+            request.method, request.url.path, str(response.status_code)
+        ).inc()
+        REQUEST_LATENCY.labels(request.url.path).observe(time.time() - start)
+        return response
+
+
+def setup_metrics(app):
+    """Register metrics middleware and router on the app."""
+    app.add_middleware(MetricsMiddleware)
+    app.include_router(router)


### PR DESCRIPTION
## Summary
- expose `/healthz`, `/readyz`, and Prometheus metrics in auth service
- define container resources and HPA with CPU-based scaling
- configure liveness/readiness probes in auth deployment

## Testing
- `npx -y @stoplight/spectral-cli lint *.yaml -D`
- `ruff check .`
- `black --check services/auth/app/main.py services/auth/app/metrics.py`
- `pytest -q`
- `gofmt -l .`
- `golangci-lint run` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: could not read package.json)*
- `docker build -f services/auth/Dockerfile services/auth` *(fails: command not found: docker)*
- `helm template deploy/helm/auth | kubeval --ignore-missing-schemas` *(fails: command not found: helm, kubeval)*

------
https://chatgpt.com/codex/tasks/task_e_689cb49ab1d4833095881433315ae35c