### PR TITLE
A3.5 feat: add auth probes metrics and HPA config

### DIFF
--- a/deploy/helm/auth/templates/deployment.yaml
+++ b/deploy/helm/auth/templates/deployment.yaml
@@ -24,9 +24,17 @@ spec:
               containerPort: {{ .Values.service.port }}
           env:
 {{- toYaml .Values.env | nindent 16 }}
-          readinessProbe:
+          livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/auth/values.dev.yaml
+++ b/deploy/helm/auth/values.dev.yaml
@@ -9,3 +9,17 @@ imagePullSecrets:
 
 ingress:
   enabled: false  # exposed only via api-gateway
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70

--- a/deploy/helm/auth/values.yaml
+++ b/deploy/helm/auth/values.yaml
@@ -10,7 +10,19 @@ imagePullSecrets: []  # e.g. [{ name: ghcr }]
 service:
   port: 8000
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
 
 env: []  # e.g. [{ name: SOME_VAR, value: "value" }]
 

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,11 +1,23 @@
 from fastapi import FastAPI
 
+from .metrics import MetricsMiddleware, metrics
 from .routers import email
 
 app = FastAPI(title="Auth Service")
+app.add_middleware(MetricsMiddleware)
 app.include_router(email.router)
 
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok", "service": "auth"}
+
+
+@app.get("/readyz")
+def readyz():
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics_endpoint():
+    return metrics()

--- a/services/auth/app/metrics.py
+++ b/services/auth/app/metrics.py
@@ -1,0 +1,27 @@
+from time import time
+
+from fastapi import Request, Response
+from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+REQUEST_COUNT = Counter(
+    "auth_request_total", "Total HTTP requests", ["method", "endpoint", "http_status"]
+)
+REQUEST_LATENCY = Histogram(
+    "auth_request_latency_seconds", "Request latency in seconds", ["endpoint"]
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start = time()
+        response = await call_next(request)
+        REQUEST_COUNT.labels(
+            request.method, request.url.path, response.status_code
+        ).inc()
+        REQUEST_LATENCY.labels(request.url.path).observe(time() - start)
+        return response
+
+
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- add Prometheus metrics and middleware for auth service
- expose /readyz and /metrics endpoints
- define liveness/readiness probes, resources, and HPA config in Helm chart

## Testing
- `ruff check .`
- `black --check services/auth/app/main.py services/auth/app/metrics.py`
- `pytest -q`
- `npx -y @stoplight/spectral-cli lint -r libs/contracts/.spectral.yaml libs/contracts/*.yaml -D`
- `helm template deploy/helm/auth | kubeval --ignore-missing-schemas` *(fails: command not found)*
- `docker build -f services/auth/Dockerfile services/auth` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cb49ab1d4833095881433315ae35c