### PR TITLE
A3.6 chore: containerize auth service

### DIFF
--- a/.github/workflows/docker-auth.yml
+++ b/.github/workflows/docker-auth.yml
@@ -1,0 +1,34 @@
+name: auth docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/auth/**'
+      - '.github/workflows/docker-auth.yml'
+  pull_request:
+    paths:
+      - 'services/auth/**'
+      - '.github/workflows/docker-auth.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./services/auth
+          file: ./services/auth/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ github.repository_owner }}/auth:latest

--- a/deploy/helm/auth/values.yaml
+++ b/deploy/helm/auth/values.yaml
@@ -18,6 +18,20 @@ resources:
     cpu: 200m
     memory: 256Mi
 
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
 hpa:
   enabled: true
   minReplicas: 1

--- a/services/auth/.dockerignore
+++ b/services/auth/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+build/
+dist/
+.git
+/tests

--- a/services/auth/Dockerfile
+++ b/services/auth/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim AS builder
+RUN pip install --prefix=/install --no-cache-dir fastapi uvicorn sqlalchemy
+
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY app /app/app
+USER 1000
+ENV PORT=8000
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- build non-root multi-stage Docker image for Auth service
- add Dockerfile context pruning via `.dockerignore`
- configure Helm values with liveness/readiness probes
- add GitHub Actions workflow to build/push Auth image

## Testing
- `npx --yes @stoplight/spectral-cli lint libs/contracts/*.yaml -D` *(fails: No ruleset found)*
- `ruff check .`
- `black --check services/auth`
- `pytest -q`
- `gofmt -l .`
- `golangci-lint run ./services/content/...` *(fails: no Go module)*
- `go test ./...` *(fails: no Go module)*
- `npx eslint .` *(fails: missing config)*
- `npm test -s` *(fails: no package.json)*
- `docker build -f services/auth/Dockerfile services/auth` *(fails: Docker daemon unavailable)*
- `helm template deploy/helm/auth | kubeval --ignore-missing-schemas`


------
https://chatgpt.com/codex/tasks/task_e_689cba1a95048330b0d89e5fdfabf8bb