### PR TITLE
Add auth service test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install pytest
+      - run: pip install -r requirements.txt
       - run: pytest -q
 
   build_and_push:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+alembic
+sqlalchemy
+pydantic
+prometheus_client
+email-validator
+pytest
+httpx


### PR DESCRIPTION
## Summary
- list auth service and test packages in new requirements file
- install requirements in CI before running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cca44fc7c8330b219e1b8b001da7b