### PR TITLE
PR4.5 PR4.6: add probes, metrics and dockerize profile

### DIFF
--- a/.github/workflows/docker-profile.yml
+++ b/.github/workflows/docker-profile.yml
@@ -1,0 +1,34 @@
+name: profile docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/profile/**'
+      - '.github/workflows/docker-profile.yml'
+  pull_request:
+    paths:
+      - 'services/profile/**'
+      - '.github/workflows/docker-profile.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./services/profile
+          file: ./services/profile/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ github.repository_owner }}/profile:latest

--- a/deploy/helm/profile/templates/deployment.yaml
+++ b/deploy/helm/profile/templates/deployment.yaml
@@ -24,9 +24,38 @@ spec:
               containerPort: {{ .Values.service.port }}
           env:
 {{- toYaml .Values.env | nindent 16 }}
-          readinessProbe:
+          livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.hpa.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "svc.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "svc.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/profile/values.dev.yaml
+++ b/deploy/helm/profile/values.dev.yaml
@@ -15,3 +15,17 @@ env:
 
 ingress:
   enabled: false  # exposed only via api-gateway
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70

--- a/deploy/helm/profile/values.yaml
+++ b/deploy/helm/profile/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: "ghcr.io/M1aso/{{ .Chart.Name }}"
+  repository: "ghcr.io/M1aso/profile"
   tag: "latest"
   pullPolicy: IfNotPresent
 
@@ -10,7 +10,33 @@ imagePullSecrets: []  # e.g. [{ name: ghcr }]
 service:
   port: 8000
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
 
 env:
   - name: MINIO_ENDPOINT

--- a/services/profile/.dockerignore
+++ b/services/profile/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+build/
+dist/
+.git
+/tests

--- a/services/profile/Dockerfile
+++ b/services/profile/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim AS builder
+RUN pip install --prefix=/install --no-cache-dir fastapi uvicorn sqlalchemy prometheus_client
+
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY app /app/app
+USER 1000
+ENV PORT=8000
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/profile/app/main.py
+++ b/services/profile/app/main.py
@@ -1,8 +1,21 @@
 from fastapi import FastAPI
 
+from .metrics import MetricsMiddleware, metrics
+
 app = FastAPI(title="Profile Service")
+app.add_middleware(MetricsMiddleware)
 
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok", "service": "profile"}
+
+
+@app.get("/readyz")
+def readyz():
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics_endpoint():
+    return metrics()

--- a/services/profile/app/metrics.py
+++ b/services/profile/app/metrics.py
@@ -1,0 +1,29 @@
+from time import time
+
+from fastapi import Request, Response
+from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+REQUEST_COUNT = Counter(
+    "profile_request_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "http_status"],
+)
+REQUEST_LATENCY = Histogram(
+    "profile_request_latency_seconds", "Request latency in seconds", ["endpoint"]
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start = time()
+        response = await call_next(request)
+        REQUEST_COUNT.labels(
+            request.method, request.url.path, response.status_code
+        ).inc()
+        REQUEST_LATENCY.labels(request.url.path).observe(time() - start)
+        return response
+
+
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- add Prometheus metrics middleware and health/readiness endpoints
- define probes, resources and HPA in Profile Helm chart
- add Dockerfile, .dockerignore and CI workflow for Profile image

## Testing
- `npx -y @stoplight/spectral-cli lint libs/contracts/*.yaml -D` *(fails: Cannot find module 'es-object-atoms/isObject')*
- `ruff check .`
- `black --check .`
- `pytest -q`
- `docker build -f services/profile/Dockerfile services/profile` *(fails: docker: command not found)*
- `helm template deploy/helm/profile` *(fails: command not found: helm)*
- `kubeval --version` *(fails: command not found: kubeval)*

------
https://chatgpt.com/codex/tasks/task_e_689ce5c882d08330bd631c4ddabaea6a