### PR TITLE
CW6.1 CW6.2: add content worker with HLS transcode

### DIFF
--- a/deploy/helm/content-worker/Chart.yaml
+++ b/deploy/helm/content-worker/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: content-worker
+description: Content worker for media transcoding
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/content-worker/templates/_helpers.tpl
+++ b/deploy/helm/content-worker/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "svc.fullname" -}}
+{{- printf "%s" .Chart.Name -}}
+{{- end -}}

--- a/deploy/helm/content-worker/templates/deployment.yaml
+++ b/deploy/helm/content-worker/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: { app: {{ include "svc.fullname" . }} }
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: { app: {{ include "svc.fullname" . }} }
+  template:
+    metadata:
+      labels: { app: {{ include "svc.fullname" . }} }
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "svc.fullname" . }}
+          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+{{- toYaml .Values.env | nindent 12 }}
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/content-worker/values.dev.yaml
+++ b/deploy/helm/content-worker/values.dev.yaml
@@ -1,0 +1,2 @@
+image:
+  tag: dev

--- a/deploy/helm/content-worker/values.yaml
+++ b/deploy/helm/content-worker/values.yaml
@@ -1,0 +1,8 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/example/content-worker
+  tag: latest
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+env: []
+resources: {}

--- a/services/content-worker/Dockerfile
+++ b/services/content-worker/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim AS builder
+WORKDIR /tmp
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+FROM python:3.12-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY app /app/app
+USER 1000
+CMD ["celery", "-A", "app.worker.celery_app", "worker", "-Q", "content-transcode", "--loglevel=info"]

--- a/services/content-worker/app/clients/content_api.py
+++ b/services/content-worker/app/clients/content_api.py
@@ -1,0 +1,14 @@
+import os
+from typing import Any, Dict
+
+import requests
+
+
+class ContentAPI:
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or os.getenv("CONTENT_API_URL", "http://content:8000")
+
+    def update_asset(self, asset_id: str, data: Dict[str, Any]) -> None:
+        url = f"{self.base_url}/api/media-assets/{asset_id}"
+        resp = requests.patch(url, json=data, timeout=5)
+        resp.raise_for_status()

--- a/services/content-worker/app/presets.yaml
+++ b/services/content-worker/app/presets.yaml
@@ -1,0 +1,36 @@
+hls-720p:
+  ffmpeg_args:
+    - -vf
+    - scale=-2:720
+    - -c:v
+    - libx264
+    - -b:v
+    - 2000k
+    - -c:a
+    - aac
+    - -b:a
+    - 128k
+    - -f
+    - hls
+    - -hls_time
+    - '4'
+    - -hls_playlist_type
+    - vod
+hls-1080p:
+  ffmpeg_args:
+    - -vf
+    - scale=-2:1080
+    - -c:v
+    - libx264
+    - -b:v
+    - 5000k
+    - -c:a
+    - aac
+    - -b:a
+    - 192k
+    - -f
+    - hls
+    - -hls_time
+    - '4'
+    - -hls_playlist_type
+    - vod

--- a/services/content-worker/app/tasks/transcode.py
+++ b/services/content-worker/app/tasks/transcode.py
@@ -1,0 +1,51 @@
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+import yaml
+from prometheus_client import Counter
+
+from clients.content_api import ContentAPI
+
+logger = logging.getLogger(__name__)
+retry_counter = Counter(
+    "transcode_retries_total", "Total transcode retries", ["preset"]
+)
+
+PRESETS_PATH = Path(__file__).resolve().parents[1] / "presets.yaml"
+with open(PRESETS_PATH, "r", encoding="utf-8") as f:
+    PRESETS = yaml.safe_load(f)
+
+
+def transcode_video(
+    asset_id: str, source_path: str, preset: str, *, client=None, max_retries: int = 3
+):
+    if preset not in PRESETS:
+        raise ValueError(f"Unknown preset {preset}")
+    client = client or ContentAPI()
+    ff_args = PRESETS[preset]["ffmpeg_args"]
+    src = Path(source_path)
+    output_path = str(src.with_name(f"{src.stem}_{preset}.m3u8"))
+    cmd = ["ffmpeg", "-y", "-i", source_path] + ff_args + [output_path]
+
+    for attempt in range(max_retries + 1):
+        try:
+            subprocess.run(
+                cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            client.update_asset(
+                asset_id, {"status": "ready", "renditions": {preset: output_path}}
+            )
+            return output_path
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("transcode attempt %s failed: %s", attempt + 1, exc)
+            retry_counter.labels(preset=preset).inc()
+            if attempt < max_retries:
+                time.sleep(2**attempt)
+                continue
+            client.update_asset(asset_id, {"status": "failed", "error": str(exc)})
+            raise
+
+
+__all__ = ["transcode_video"]

--- a/services/content-worker/app/worker.py
+++ b/services/content-worker/app/worker.py
@@ -1,0 +1,13 @@
+import os
+from celery import Celery
+from kombu import Queue
+
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672//")
+RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://redis:6379/0")
+
+celery_app = Celery("content_worker", broker=RABBITMQ_URL, backend=RESULT_BACKEND)
+celery_app.conf.task_queues = (Queue("content-transcode", durable=True),)
+celery_app.conf.task_default_queue = "content-transcode"
+
+# ensure tasks are registered
+from app.tasks import transcode  # noqa: E402,F401

--- a/services/content-worker/requirements.txt
+++ b/services/content-worker/requirements.txt
@@ -1,0 +1,4 @@
+celery==5.3.4
+requests==2.31.0
+prometheus-client==0.19.0
+PyYAML==6.0.1

--- a/services/content-worker/tests/test_transcode.py
+++ b/services/content-worker/tests/test_transcode.py
@@ -1,0 +1,51 @@
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+from tasks.transcode import transcode_video  # noqa: E402
+
+
+class DummyClient:
+    def __init__(self):
+        self.calls = []
+
+    def update_asset(self, asset_id, data):
+        self.calls.append((asset_id, data))
+
+
+def test_transcode_success(monkeypatch, tmp_path):
+    def fake_run(cmd, check, stdout, stderr):
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    client = DummyClient()
+    src = tmp_path / "video.mp4"
+    src.write_text("fake")
+    out = transcode_video("asset1", str(src), "hls-720p", client=client)
+    assert out.endswith("_hls-720p.m3u8")
+    assert client.calls == [
+        ("asset1", {"status": "ready", "renditions": {"hls-720p": out}})
+    ]
+
+
+def test_transcode_retry_failure(monkeypatch, tmp_path):
+    attempts = {"n": 0}
+
+    def fake_run(cmd, check, stdout, stderr):
+        attempts["n"] += 1
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    client = DummyClient()
+    src = tmp_path / "video.mp4"
+    src.write_text("fake")
+    with pytest.raises(subprocess.CalledProcessError):
+        transcode_video("asset1", str(src), "hls-720p", client=client)
+    assert attempts["n"] == 4
+    assert client.calls[-1][1]["status"] == "failed"


### PR DESCRIPTION
## Summary
- add Celery worker bound to RabbitMQ and durable queue
- implement ffmpeg HLS transcode with retries and asset status updates
- helm chart, Dockerfile, presets and client for Content API

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `npx -y @stoplight/spectral-cli lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -D`
- `gofmt -l .` *(pass: no output)*
- `golangci-lint run` *(fail: directory prefix . does not contain main module)*
- `go test ./...` *(fail: directory prefix . does not contain main module)*
- `eslint .` *(fail: missing config)
- `npm test -s`
- `docker build -f services/content-worker/Dockerfile services/content-worker` *(fail: command not found)
- `helm template deploy/helm/content-worker` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da414d1108330adcc98155385878e