### PR TITLE
CH9.1 CH9.2: add chat history store with moderation

### DIFF
--- a/services/chat/src/db/index.ts
+++ b/services/chat/src/db/index.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'crypto';
+
+export interface Attachment {
+  id: string;
+  url: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  createdAt: Date;
+}
+
+export interface Message {
+  id: string;
+  dialogId: string;
+  senderId: string;
+  content: string;
+  createdAt: Date;
+  deletedAt: Date | null;
+  attachments: Attachment[];
+}
+
+export class ChatDB {
+  private dialogs = new Set<string>();
+  private messages = new Map<string, Message>();
+  private byDialog = new Map<string, Message[]>();
+
+  createDialog(id?: string): string {
+    const dialogId = id || randomUUID();
+    this.dialogs.add(dialogId);
+    if (!this.byDialog.has(dialogId)) this.byDialog.set(dialogId, []);
+    return dialogId;
+  }
+
+  appendMessage(
+    dialogId: string,
+    senderId: string,
+    content: string,
+    attachments: Array<{
+      url: string;
+      mimeType?: string;
+      sizeBytes?: number;
+    }> = []
+  ): Message {
+    if (!this.dialogs.has(dialogId)) this.createDialog(dialogId);
+    const msg: Message = {
+      id: randomUUID(),
+      dialogId,
+      senderId,
+      content,
+      createdAt: new Date(),
+      deletedAt: null,
+      attachments: attachments.map((a) => ({
+        id: randomUUID(),
+        url: a.url,
+        mimeType: a.mimeType,
+        sizeBytes: a.sizeBytes,
+        createdAt: new Date(),
+      })),
+    };
+    this.messages.set(msg.id, msg);
+    this.byDialog.get(dialogId)!.push(msg);
+    return msg;
+  }
+
+  softDeleteMessage(id: string): void {
+    const msg = this.messages.get(id);
+    if (msg && !msg.deletedAt) {
+      msg.deletedAt = new Date();
+    }
+  }
+
+  getMessages(
+    dialogId: string,
+    limit = 20,
+    cursor?: string
+  ): { messages: Message[]; nextCursor: string | null } {
+    const all = this.byDialog.get(dialogId) || [];
+    const visible = all.filter((m) => !m.deletedAt);
+    visible.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    let start = 0;
+    if (cursor) {
+      const idx = visible.findIndex((m) => m.id === cursor);
+      if (idx !== -1) start = idx + 1;
+    }
+    const slice = visible.slice(start, start + limit);
+    const nextCursor = start + slice.length < visible.length ? slice[slice.length - 1].id : null;
+    return { messages: slice, nextCursor };
+  }
+
+  presignAttachment(filename: string): string {
+    const id = randomUUID();
+    return `https://minio.local/${id}/${encodeURIComponent(filename)}`;
+  }
+}
+
+export default ChatDB;

--- a/services/chat/src/db/migrations/001_init.sql
+++ b/services/chat/src/db/migrations/001_init.sql
@@ -1,0 +1,22 @@
+CREATE TABLE dialogs (
+  id UUID PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE messages (
+  id UUID PRIMARY KEY,
+  dialog_id UUID REFERENCES dialogs(id),
+  sender_id UUID NOT NULL,
+  content TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE attachments (
+  id UUID PRIMARY KEY,
+  message_id UUID REFERENCES messages(id),
+  url TEXT NOT NULL,
+  mime_type VARCHAR(100),
+  size_bytes BIGINT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/services/chat/src/http/history.ts
+++ b/services/chat/src/http/history.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import type ChatDB from '../db';
+
+export function historyHandler(db: ChatDB): express.Handler {
+  return (req, res) => {
+    const { dialogId } = req.params as { dialogId: string };
+    const limit = Number((req.query.limit as string) || 20);
+    const cursor = req.query.cursor as string | undefined;
+    const result = db.getMessages(dialogId, limit, cursor);
+    res.json(result);
+  };
+}
+
+export function createHistoryRouter(db: ChatDB): express.Router {
+  const router = express.Router();
+  router.get('/dialogs/:dialogId/history', historyHandler(db));
+  return router;
+}
+
+export default createHistoryRouter;

--- a/services/chat/src/moderation.ts
+++ b/services/chat/src/moderation.ts
@@ -1,0 +1,41 @@
+import type ChatDB from './db';
+
+export type Filter = (text: string) => boolean;
+
+export interface AuditEntry {
+  adminId: string;
+  messageId: string;
+  deletedAt: Date;
+}
+
+export class ModerationService {
+  private blocklist: Set<string>;
+  private filters: Filter[];
+  public auditLog: AuditEntry[] = [];
+
+  constructor(blocked: string[] = [], filters: Filter[] = []) {
+    this.blocklist = new Set(blocked);
+    const profanity = (text: string) => {
+      const bad = ['badword'];
+      const lower = text.toLowerCase();
+      return !bad.some((w) => lower.includes(w));
+    };
+    this.filters = [profanity, ...filters];
+  }
+
+  isBlocked(userId: string): boolean {
+    return this.blocklist.has(userId);
+  }
+
+  checkMessage(userId: string, text: string): void {
+    if (this.isBlocked(userId)) throw new Error('blocked');
+    if (!this.filters.every((f) => f(text))) throw new Error('profanity');
+  }
+
+  deleteMessageAsAdmin(db: ChatDB, messageId: string, adminId: string): void {
+    db.softDeleteMessage(messageId);
+    this.auditLog.push({ adminId, messageId, deletedAt: new Date() });
+  }
+}
+
+export default ModerationService;

--- a/services/chat/src/rate_limit.ts
+++ b/services/chat/src/rate_limit.ts
@@ -1,0 +1,21 @@
+export class RateLimiter {
+  private limit: number;
+  private windowMs: number;
+  private hits = new Map<string, number[]>();
+
+  constructor(limit = 20, windowMs = 10000) {
+    this.limit = limit;
+    this.windowMs = windowMs;
+  }
+
+  attempt(userId: string): boolean {
+    const now = Date.now();
+    const arr = this.hits.get(userId) || [];
+    const fresh = arr.filter((ts) => now - ts < this.windowMs);
+    fresh.push(now);
+    this.hits.set(userId, fresh);
+    return fresh.length <= this.limit;
+  }
+}
+
+export default RateLimiter;

--- a/services/chat/tests/history.test.ts
+++ b/services/chat/tests/history.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import ChatDB from '../src/db';
+import { historyHandler } from '../src/http/history';
+
+function callHandler(handler: any, req: any) {
+  return new Promise((resolve) => {
+    const res = { json: (body: unknown) => resolve(body) };
+    handler(req, res);
+  });
+}
+
+describe('history endpoint', () => {
+  it('paginates messages and skips deleted', async () => {
+    const db = new ChatDB();
+    const dialog = db.createDialog();
+    const m1 = db.appendMessage(dialog, 'u1', 'hello');
+    const m2 = db.appendMessage(dialog, 'u2', 'hi');
+    const m3 = db.appendMessage(dialog, 'u1', 'third', [{ url: 'http://file', mimeType: 'text/plain' }]);
+    db.softDeleteMessage(m2.id);
+
+    const handler = historyHandler(db);
+    const page1: any = await callHandler(handler, { params: { dialogId: dialog }, query: { limit: '2' } });
+    expect(page1.messages).toHaveLength(2);
+    expect(page1.messages[0].id).toBe(m1.id);
+    expect(page1.messages[1].id).toBe(m3.id);
+    expect(page1.messages[1].attachments).toHaveLength(1);
+    expect(page1.nextCursor).toBeNull();
+  });
+
+  it('supports cursor pagination', async () => {
+    const db = new ChatDB();
+    const dialog = db.createDialog();
+    db.appendMessage(dialog, 'u1', 'm1');
+    db.appendMessage(dialog, 'u1', 'm2');
+    const m3 = db.appendMessage(dialog, 'u1', 'm3');
+
+    const handler = historyHandler(db);
+    const first: any = await callHandler(handler, { params: { dialogId: dialog }, query: { limit: '2' } });
+    expect(first.messages).toHaveLength(2);
+    const next: any = await callHandler(handler, {
+      params: { dialogId: dialog },
+      query: { limit: '2', cursor: first.nextCursor },
+    });
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0].id).toBe(m3.id);
+  });
+});

--- a/services/chat/tests/rate_moderation.test.ts
+++ b/services/chat/tests/rate_moderation.test.ts
@@ -1,0 +1,31 @@
+import ChatDB from '../src/db';
+import ModerationService from '../src/moderation';
+import RateLimiter from '../src/rate_limit';
+
+describe('rate limiting and moderation', () => {
+  it('limits messages per user', () => {
+    const limiter = new RateLimiter(2, 1000);
+    expect(limiter.attempt('u1')).toBe(true);
+    expect(limiter.attempt('u1')).toBe(true);
+    expect(limiter.attempt('u1')).toBe(false);
+  });
+
+  it('blocks users and detects profanity', () => {
+    const mod = new ModerationService(['badguy']);
+    expect(() => mod.checkMessage('badguy', 'hi')).toThrow('blocked');
+    expect(() => mod.checkMessage('u1', 'this has badword in it')).toThrow('profanity');
+    expect(() => mod.checkMessage('u1', 'clean message')).not.toThrow();
+  });
+
+  it('admin deletions are audited', () => {
+    const db = new ChatDB();
+    const mod = new ModerationService();
+    const dialog = db.createDialog();
+    const msg = db.appendMessage(dialog, 'u1', 'hi');
+    mod.deleteMessageAsAdmin(db, msg.id, 'admin');
+    const log = mod.auditLog[0];
+    expect(log).toMatchObject({ adminId: 'admin', messageId: msg.id });
+    const history = db.getMessages(dialog);
+    expect(history.messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement in-memory message store with attachments, soft delete and cursor pagination
- expose history endpoint for dialogs
- add rate limiter and moderation service with audit logging

## Testing
- `npx @stoplight/spectral-cli lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -D`
- `ruff check .`
- `black --check . --exclude node_modules`
- `pytest -q`
- `npx eslint .`
- `npm test -- -i`
- `golangci-lint run` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `docker build -f services/chat/Dockerfile services/chat` *(fails: command not found: docker)*
- `helm template deploy/helm/chat | kubeval --ignore-missing-schemas` *(fails: command not found: helm)*

------
https://chatgpt.com/codex/tasks/task_e_689db8100bbc83308f7c27becf37e0d7