### PR TITLE
AN10: analytics ingestion, reports, worker and container

### DIFF
--- a/.github/workflows/docker-analytics.yml
+++ b/.github/workflows/docker-analytics.yml
@@ -1,0 +1,34 @@
+name: analytics docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/analytics/**'
+      - '.github/workflows/docker-analytics.yml'
+  pull_request:
+    paths:
+      - 'services/analytics/**'
+      - '.github/workflows/docker-analytics.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./services/analytics
+          file: ./services/analytics/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ github.repository_owner }}/analytics:latest

--- a/deploy/helm/analytics/templates/deployment.yaml
+++ b/deploy/helm/analytics/templates/deployment.yaml
@@ -24,9 +24,38 @@ spec:
               containerPort: {{ .Values.service.port }}
           env:
 {{- toYaml .Values.env | nindent 16 }}
-          readinessProbe:
+          livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.hpa.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "svc.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "svc.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/analytics/values.yaml
+++ b/deploy/helm/analytics/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: "ghcr.io/M1aso/{{ .Chart.Name }}"
+  repository: "ghcr.io/M1aso/analytics"
   tag: "latest"
   pullPolicy: IfNotPresent
 
@@ -10,9 +10,39 @@ imagePullSecrets: []  # e.g. [{ name: ghcr }]
 service:
   port: 8000
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
 
-env: []  # e.g. [{ name: SOME_VAR, value: "value" }]
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+env:
+  - name: MINIO_ENDPOINT
+    value: "minio:9000"
+  - name: MINIO_BUCKET
+    value: "reports"
 
 ingress:
   enabled: false

--- a/libs/contracts/analytics.yaml
+++ b/libs/contracts/analytics.yaml
@@ -15,3 +15,78 @@ paths:
       summary: Get dashboard metrics
       responses:
         '200': { description: OK }
+
+  /api/analytics/ingest:
+    post:
+      summary: Ingest batch of events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Event'
+      responses:
+        '200':
+          description: Ingested
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ingested:
+                    type: integer
+        '413':
+          description: Batch too large
+
+  /api/analytics/reports/dau:
+    get:
+      summary: Daily active users count
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dau:
+                    type: integer
+
+  /api/analytics/reports/events:
+    get:
+      summary: Export events
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [csv, xlsx]
+          required: true
+      responses:
+        '200':
+          description: Export stream
+          content:
+            text/csv: {}
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet: {}
+
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        ts:
+          type: string
+          format: date-time
+        user_id:
+          type: string
+          format: uuid
+        type:
+          type: string
+        src:
+          type: string
+          nullable: true
+        payload:
+          type: object
+      required: [ts, user_id, type, payload]

--- a/services/analytics/.dockerignore
+++ b/services/analytics/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+build/
+dist/
+.git
+/tests

--- a/services/analytics/Dockerfile
+++ b/services/analytics/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim AS builder
+RUN pip install --prefix=/install --no-cache-dir fastapi uvicorn sqlalchemy prometheus_client openpyxl celery
+
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY app /app/app
+USER 1000
+ENV PORT=8000
+EXPOSE 8000
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/services/analytics/app/clients/storage.py
+++ b/services/analytics/app/clients/storage.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+class StorageClient:
+    def __init__(self, base_path: str = "storage"):
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def upload_bytes(self, data: bytes, object_name: str) -> str:
+        path = self.base_path / object_name
+        path.write_bytes(data)
+        return str(path)
+
+    def presigned_get(self, object_name: str) -> str:
+        path = self.base_path / object_name
+        return path.as_uri()

--- a/services/analytics/app/db/migrations/alembic.ini
+++ b/services/analytics/app/db/migrations/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = services/analytics/app/db/migrations
+sqlalchemy.url = sqlite:///./analytics.db

--- a/services/analytics/app/db/migrations/env.py
+++ b/services/analytics/app/db/migrations/env.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(str(Path(__file__).resolve().parents[5]))
+from services.analytics.app.db import models  # noqa: E402,F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    try:
+        fileConfig(config.config_file_name)
+    except KeyError:
+        pass
+
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option(
+        "sqlalchemy.url", os.getenv("DATABASE_URL", "sqlite:///./analytics.db")
+    )
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/analytics/app/db/migrations/versions/0001_create_events_table.py
+++ b/services/analytics/app/db/migrations/versions/0001_create_events_table.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("user_id", sa.String(36), nullable=False),
+        sa.Column("type", sa.String(50), nullable=False),
+        sa.Column("src", sa.String(100)),
+        sa.Column("payload", sa.JSON, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("events")

--- a/services/analytics/app/db/models.py
+++ b/services/analytics/app/db/models.py
@@ -1,0 +1,33 @@
+import os
+from sqlalchemy import Column, DateTime, Integer, String, JSON, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./analytics.db")
+engine = create_engine(
+    DATABASE_URL,
+    connect_args=(
+        {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+    ),
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ts = Column(DateTime(timezone=True), nullable=False)
+    user_id = Column(String(36), nullable=False)
+    type = Column(String(50), nullable=False)
+    src = Column(String(100))
+    payload = Column(JSON, nullable=False)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/analytics/app/main.py
+++ b/services/analytics/app/main.py
@@ -1,8 +1,50 @@
-from fastapi import FastAPI
+from time import time
+
+from fastapi import FastAPI, Request, Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+from starlette.middleware.base import BaseHTTPMiddleware
 
 app = FastAPI(title="Analytics Service")
+
+REQUEST_COUNT = Counter(
+    "analytics_request_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "http_status"],
+)
+REQUEST_LATENCY = Histogram(
+    "analytics_request_latency_seconds", "Request latency in seconds", ["endpoint"]
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start = time()
+        response = await call_next(request)
+        REQUEST_COUNT.labels(
+            request.method, request.url.path, response.status_code
+        ).inc()
+        REQUEST_LATENCY.labels(request.url.path).observe(time() - start)
+        return response
+
+
+app.add_middleware(MetricsMiddleware)
 
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok", "service": "analytics"}
+
+
+@app.get("/readyz")
+def readyz():
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/analytics/app/routers/ingest.py
+++ b/services/analytics/app/routers/ingest.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..db.models import Event, get_db
+
+router = APIRouter(prefix="/api/analytics", tags=["ingest"])
+
+MAX_BATCH_SIZE = 1000
+
+
+class EventIn(BaseModel):
+    ts: datetime
+    user_id: str
+    type: str
+    src: Optional[str] = None
+    payload: dict
+
+
+@router.post("/ingest")
+def ingest(events: List[EventIn], db: Session = Depends(get_db)):
+    if len(events) > MAX_BATCH_SIZE:
+        raise HTTPException(status_code=413, detail="batch too large")
+    db.add_all([Event(**e.dict()) for e in events])
+    db.commit()
+    return {"ingested": len(events)}

--- a/services/analytics/app/routers/reports.py
+++ b/services/analytics/app/routers/reports.py
@@ -1,0 +1,63 @@
+import csv
+import io
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+from openpyxl import Workbook
+
+from ..db.models import Event, get_db
+
+router = APIRouter(prefix="/api/analytics/reports", tags=["reports"])
+
+
+@router.get("/dau")
+def daily_active_users(db: Session = Depends(get_db)):
+    today = datetime.utcnow().date()
+    start = datetime.combine(today, datetime.min.time())
+    end = start + timedelta(days=1)
+    count = (
+        db.query(Event.user_id)
+        .filter(Event.ts >= start, Event.ts < end)
+        .distinct()
+        .count()
+    )
+    return {"dau": count}
+
+
+@router.get("/events")
+def export_events(
+    format: str = Query(..., regex="^(csv|xlsx)$"), db: Session = Depends(get_db)
+):
+    events = db.query(Event).order_by(Event.id).all()
+    if format == "csv":
+
+        def generate():
+            output = io.StringIO()
+            writer = csv.writer(output)
+            writer.writerow(["ts", "user_id", "type", "src"])
+            yield output.getvalue()
+            output.seek(0)
+            output.truncate(0)
+            for e in events:
+                writer.writerow([e.ts.isoformat(), e.user_id, e.type, e.src or ""])
+                yield output.getvalue()
+                output.seek(0)
+                output.truncate(0)
+
+        return StreamingResponse(generate(), media_type="text/csv")
+    if format == "xlsx":
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["ts", "user_id", "type", "src"])
+        for e in events:
+            ws.append([e.ts.isoformat(), e.user_id, e.type, e.src])
+        stream = io.BytesIO()
+        wb.save(stream)
+        stream.seek(0)
+        return StreamingResponse(
+            stream,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    raise HTTPException(status_code=400, detail="unsupported format")

--- a/services/analytics/app/worker.py
+++ b/services/analytics/app/worker.py
@@ -1,0 +1,17 @@
+import os
+from celery import Celery
+
+from .clients.storage import StorageClient
+
+celery_app = Celery(
+    "analytics_worker", broker=os.getenv("CELERY_BROKER_URL", "memory://")
+)
+
+
+@celery_app.task
+def generate_pdf(name: str, content: str) -> str:
+    data = content.encode()
+    storage = StorageClient()
+    object_name = f"{name}.pdf"
+    storage.upload_bytes(data, object_name)
+    return storage.presigned_get(object_name)

--- a/services/analytics/tests/test_ingest.py
+++ b/services/analytics/tests/test_ingest.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from services.analytics.app.db.models import Base, Event, get_db
+from services.analytics.app.routers.ingest import (
+    router as ingest_router,
+    MAX_BATCH_SIZE,
+)
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    app = FastAPI()
+    app.include_router(ingest_router)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return app, TestingSessionLocal
+
+
+def test_ingest_and_limit():
+    app, SessionLocal = setup_app()
+    client = TestClient(app)
+
+    events = [
+        {
+            "ts": datetime.utcnow().isoformat(),
+            "user_id": "u1",
+            "type": "click",
+            "payload": {"a": 1},
+        },
+        {
+            "ts": datetime.utcnow().isoformat(),
+            "user_id": "u2",
+            "type": "view",
+            "payload": {"b": 2},
+        },
+    ]
+    resp = client.post("/api/analytics/ingest", json=events)
+    assert resp.status_code == 200
+    assert resp.json() == {"ingested": 2}
+
+    db = SessionLocal()
+    assert db.query(Event).count() == 2
+    db.close()
+
+    big_batch = events * (MAX_BATCH_SIZE // len(events) + 1)
+    resp = client.post("/api/analytics/ingest", json=big_batch)
+    assert resp.status_code == 413

--- a/services/analytics/tests/test_reports.py
+++ b/services/analytics/tests/test_reports.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from services.analytics.app.db.models import Base, Event, get_db
+from services.analytics.app.routers.reports import router as reports_router
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    app = FastAPI()
+    app.include_router(reports_router)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return app, TestingSessionLocal
+
+
+def seed_events(SessionLocal):
+    db = SessionLocal()
+    now = datetime.utcnow()
+    yesterday = now - timedelta(days=1)
+    db.add_all(
+        [
+            Event(ts=now, user_id="u1", type="click", payload={}),
+            Event(ts=now, user_id="u2", type="view", payload={}),
+            Event(ts=yesterday, user_id="u3", type="view", payload={}),
+        ]
+    )
+    db.commit()
+    db.close()
+
+
+def test_dau_and_export_csv():
+    app, SessionLocal = setup_app()
+    seed_events(SessionLocal)
+    client = TestClient(app)
+
+    resp = client.get("/api/analytics/reports/dau")
+    assert resp.status_code == 200
+    assert resp.json()["dau"] == 2
+
+    resp = client.get("/api/analytics/reports/events", params={"format": "csv"})
+    assert resp.status_code == 200
+    lines = resp.text.strip().splitlines()
+    assert lines[0] == "ts,user_id,type,src"
+    assert len(lines) == 4


### PR DESCRIPTION
## Summary
- AN10.1 add analytics event ingestion API and schema with migrations
- AN10.2 implement basic reports endpoints with CSV/XLSX exports
- AN10.3 add PDF worker with local storage and helm settings
- AN10.4 containerize analytics service and add Docker workflow

## Testing
- `ruff check .`
- `black --check services libs tests --exclude node_modules`
- `pytest -q`
- `npx @stoplight/spectral-cli lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -D`
- `docker build -f services/analytics/Dockerfile services/analytics` *(fails: command not found)*
- `helm template deploy/helm/analytics | kubeval --ignore-missing-schemas` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dba6158a4833099495f698bd7cce2