### PR TITLE
AN10.5 chore: add openpyxl and PyYAML dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ prometheus_client
 email-validator
 pytest
 httpx
+
+openpyxl
+PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- add openpyxl for analytics reports
- pin PyYAML to 6.0.1

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc36d40b8833099541a82c6468eb9