### PR TITLE
CI0.1 chore: add docker workflows for chat and content

### DIFF
--- a/.github/workflows/docker-chat.yml
+++ b/.github/workflows/docker-chat.yml
@@ -1,0 +1,36 @@
+name: chat docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/chat/**'
+      - '.github/workflows/docker-chat.yml'
+  pull_request:
+    paths:
+      - 'services/chat/**'
+      - '.github/workflows/docker-chat.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Derive lowercase owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./services/chat
+          file: ./services/chat/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/chat:${{ github.sha }}

--- a/.github/workflows/docker-content-worker.yml
+++ b/.github/workflows/docker-content-worker.yml
@@ -1,0 +1,36 @@
+name: content-worker docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/content-worker/**'
+      - '.github/workflows/docker-content-worker.yml'
+  pull_request:
+    paths:
+      - 'services/content-worker/**'
+      - '.github/workflows/docker-content-worker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Derive lowercase owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./services/content-worker
+          file: ./services/content-worker/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/content-worker:${{ github.sha }}

--- a/.github/workflows/docker-content.yml
+++ b/.github/workflows/docker-content.yml
@@ -1,0 +1,36 @@
+name: content docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/content/**'
+      - '.github/workflows/docker-content.yml'
+  pull_request:
+    paths:
+      - 'services/content/**'
+      - '.github/workflows/docker-content.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Derive lowercase owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./services/content
+          file: ./services/content/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/content:${{ github.sha }}


### PR DESCRIPTION
## Summary
- add docker workflow for chat service
- add docker workflow for content service
- add docker workflow for content worker service

## Testing
- `npx @stoplight/spectral-cli lint "libs/contracts/*.yaml" --ruleset libs/contracts/.spectral.yaml -D`
- `ruff check .`
- `black --check . --exclude node_modules`
- `pytest -q`
- `gofmt -l .`
- `golangci-lint run` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `(cd services/chat && npx eslint . && npm test -s)`
- `for s in analytics auth chat content content-worker notifications profile; do docker build -f services/$s/Dockerfile services/$s; done` *(fails: Cannot connect to the Docker daemon)*
- `for s in analytics auth chat content content-worker notifications profile; do helm template deploy/helm/$s | kubeval --ignore-missing-schemas; done`


------
https://chatgpt.com/codex/tasks/task_e_689dcb5c55088330a54f66db0a10ec7d