### PR TITLE
Fix build push denied installation error

### DIFF
--- a/.github/workflows/docker-analytics.yml
+++ b/.github/workflows/docker-analytics.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-auth.yml
+++ b/.github/workflows/docker-auth.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-chat.yml
+++ b/.github/workflows/docker-chat.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-content-worker.yml
+++ b/.github/workflows/docker-content-worker.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-content.yml
+++ b/.github/workflows/docker-content.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-notifications.yml
+++ b/.github/workflows/docker-notifications.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner

--- a/.github/workflows/docker-profile.yml
+++ b/.github/workflows/docker-profile.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Derive lowercase owner


### PR DESCRIPTION
Add `packages: write` permission to Docker build workflows to resolve GitHub Container Registry push errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-a90feb4b-b0ce-45cb-832a-29dcc5cfbe42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a90feb4b-b0ce-45cb-832a-29dcc5cfbe42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

