### PR TITLE
Fix k3s config file permission denied

### DIFF
--- a/scripts/setup-vps.sh
+++ b/scripts/setup-vps.sh
@@ -57,8 +57,8 @@ fi
 # 3. Install k3s
 log_info "Installing k3s..."
 if ! command -v kubectl &> /dev/null; then
-    curl -sfL https://get.k3s.io | sh -
-    sudo mkdir -p ~/.kube
+    curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
+    mkdir -p ~/.kube
     sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
     sudo chown $USER:$USER ~/.kube/config
     echo "export KUBECONFIG=~/.kube/config" >> ~/.bashrc


### PR DESCRIPTION
Fix K3s kubeconfig permission error by setting `--write-kubeconfig-mode 644` during installation.

The error `open /etc/rancher/k3s/k3s.yaml: permission denied` occurred because K3s installs the kubeconfig file with default root-only permissions (600). Subsequent `kubectl` commands run by the user failed to read this file. Setting `--write-kubeconfig-mode 644` ensures the kubeconfig is readable by all users from the start, preventing this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-3177000a-eeea-4e83-93c8-375d5613b2a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3177000a-eeea-4e83-93c8-375d5613b2a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

