### PR TITLE
Fix vps backup script permission

### DIFF
--- a/scripts/setup-vps.sh
+++ b/scripts/setup-vps.sh
@@ -389,7 +389,7 @@ sudo chown $USER:$USER /opt/backups
 
 # 13. Create backup script
 log_info "Creating backup script..."
-cat <<'EOF' > /opt/backup-db.sh
+sudo tee /opt/backup-db.sh > /dev/null <<'EOF'
 #!/bin/bash
 DATE=$(date +%Y%m%d_%H%M%S)
 mkdir -p /opt/backups
@@ -398,7 +398,7 @@ find /opt/backups -name "db_backup_*.sql" -mtime +7 -delete
 echo "Database backup completed: db_backup_$DATE.sql"
 EOF
 
-chmod +x /opt/backup-db.sh
+sudo chmod +x /opt/backup-db.sh
 
 # Setup cron job for daily backups
 (crontab -l 2>/dev/null; echo "0 2 * * * /opt/backup-db.sh") | crontab -


### PR DESCRIPTION
Fix 'Permission denied' error when creating and making executable `/opt/backup-db.sh` by using `sudo tee` for file creation and `sudo chmod` for permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-f31d1dee-7811-41af-a39c-dfef3cb3433d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f31d1dee-7811-41af-a39c-dfef3cb3433d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

