### PR TITLE
Fix ghcr imagepullsecret creation failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v4
 
+      - name: Configure kubeconfig from secret
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          if [ -n "${KUBE_CONFIG:-}" ]; then
+            mkdir -p "$HOME/.kube"
+            echo "$KUBE_CONFIG" | base64 -d > "$HOME/.kube/config"
+            echo "✓ Wrote kubeconfig from secret"
+          else
+            echo "↷ KUBE_CONFIG is empty; skipping. Add it as an Environment secret."
+          fi
+
       - name: Create GHCR imagePullSecret
         env:
           NS: dev
@@ -103,18 +115,6 @@ jobs:
             echo "✓ Created imagePullSecret 'ghcr' in namespace $NS"
           else
             echo "↷ GHCR_USERNAME/GHCR_TOKEN not provided; skipping imagePullSecret creation."
-          fi
-
-      - name: Configure kubeconfig from secret
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        run: |
-          if [ -n "${KUBE_CONFIG:-}" ]; then
-            mkdir -p "$HOME/.kube"
-            echo "$KUBE_CONFIG" | base64 -d > "$HOME/.kube/config"
-            echo "✓ Wrote kubeconfig from secret"
-          else
-            echo "↷ KUBE_CONFIG is empty; skipping. Add it as an Environment secret."
           fi
 
       - name: Deploy api-gateway


### PR DESCRIPTION
Reorder `kubeconfig` configuration before `imagePullSecret` creation in `ci.yml` to fix `kubectl` connection errors.

The `auto_deploy_dev` workflow was failing because the `Create GHCR imagePullSecret` step, which uses `kubectl`, was executing before the `Configure kubeconfig from secret` step. This caused `kubectl` to attempt connecting to `localhost:8080`, resulting in a 'connection refused' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-417e11a5-2241-44bd-a3ec-789d91f8f697">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-417e11a5-2241-44bd-a3ec-789d91f8f697">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

