### PR TITLE
Fix module not found error in chat deployment

### DIFF
--- a/services/chat/Dockerfile
+++ b/services/chat/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /app/dist ./dist
 USER node
 ENV PORT=8000
 EXPOSE 8000
-CMD ["node", "dist/src/index.js"]
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Fix `MODULE_NOT_FOUND` error by correcting the Node.js entry point in the Dockerfile `CMD`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3715c8a-e02a-4536-a724-a691db2a5e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3715c8a-e02a-4536-a724-a691db2a5e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

