### PR TITLE
Fix envoy router filter configuration

### DIFF
--- a/deploy/helm/api-gateway/templates/configmap.yaml
+++ b/deploy/helm/api-gateway/templates/configmap.yaml
@@ -47,6 +47,8 @@ data:
                               requires: { provider_name: "default" }
 {{- end }}
                       - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
 {{- if .Values.jwtAuthn.enabled }}
         - name: jwks_cluster


### PR DESCRIPTION
Add `typed_config` to the Envoy HTTP router filter to fix a startup error.

The Envoy API gateway failed to start with the error "Didn't find a registered implementation for 'envoy.filters.http.router' with type URL: ''" because the `envoy.filters.http.router` filter was missing its required `typed_config` field. This change adds the necessary `typed_config` to correctly configure the router filter.

---
<a href="https://cursor.com/background-agent?bcId=bc-b52dd533-dcb9-43c5-92af-16335c919b27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b52dd533-dcb9-43c5-92af-16335c919b27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

