### PR TITLE
Fix celery worker module not found error

### DIFF
--- a/services/content-worker/app/__init__.py
+++ b/services/content-worker/app/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the app directory a Python package

--- a/services/content-worker/app/clients/__init__.py
+++ b/services/content-worker/app/clients/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the clients directory a Python package

--- a/services/content-worker/app/tasks/__init__.py
+++ b/services/content-worker/app/tasks/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the tasks directory a Python package

--- a/services/content-worker/app/tasks/transcode.py
+++ b/services/content-worker/app/tasks/transcode.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from prometheus_client import Counter
 
-from clients.content_api import ContentAPI
+from app.clients.content_api import ContentAPI
 
 logger = logging.getLogger(__name__)
 retry_counter = Counter(


### PR DESCRIPTION
Fix `ModuleNotFoundError` in Celery worker by correcting an import path and adding missing `__init__.py` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-87afc1f1-9f66-43b6-a3a3-c2d98bfb27d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87afc1f1-9f66-43b6-a3a3-c2d98bfb27d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

