### PR TITLE
Fix celery worker module not found error

### DIFF
--- a/services/content-worker/app/tasks/transcode.py
+++ b/services/content-worker/app/tasks/transcode.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from prometheus_client import Counter
 
-from clients.content_api import ContentAPI
+from app.clients.content_api import ContentAPI
 
 logger = logging.getLogger(__name__)
 retry_counter = Counter(


### PR DESCRIPTION
Correct `ContentAPI` import path to resolve `ModuleNotFoundError` in the Celery worker.

---
<a href="https://cursor.com/background-agent?bcId=bc-697d101f-d8ad-4393-bea8-a1b3e79c4462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-697d101f-d8ad-4393-bea8-a1b3e79c4462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

