### PR TITLE
Fix notification health check 404 errors

### DIFF
--- a/services/notifications/app/main.py
+++ b/services/notifications/app/main.py
@@ -6,6 +6,11 @@ app = FastAPI(title="Notifications Service")
 app.include_router(notify.router)
 
 
+@app.get("/health")
+def health():
+    return {"status": "ok", "service": "notifications"}
+
+
 @app.get("/healthz")
 def healthz():
     return {"status": "ok", "service": "notifications"}


### PR DESCRIPTION
Add `/health` endpoint to the notifications service to resolve 404 errors from Kubernetes readiness probes.

---
<a href="https://cursor.com/background-agent?bcId=bc-af4489ce-2ea4-4304-8141-ab9b64c4c218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af4489ce-2ea4-4304-8141-ab9b64c4c218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

