### PR TITLE
Fix celery worker module not found error

### DIFF
--- a/services/content-worker/app/tasks/transcode.py
+++ b/services/content-worker/app/tasks/transcode.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from prometheus_client import Counter
 
-from clients.content_api import ContentAPI
+from app.clients.content_api import ContentAPI
 
 logger = logging.getLogger(__name__)
 retry_counter = Counter(


### PR DESCRIPTION
Fix `ModuleNotFoundError` for `clients` module by correcting the import path for `ContentAPI`.

The original import `from clients.content_api import ContentAPI` failed because the `app` directory was not implicitly on the Python path in the Docker runtime. The Dockerfile sets `WORKDIR /app` and copies code to `/app/app`, making `app.clients.content_api` the correct import.

---
<a href="https://cursor.com/background-agent?bcId=bc-5330a2bc-42c5-47d9-855f-ee84a4671d97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5330a2bc-42c5-47d9-855f-ee84a4671d97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

